### PR TITLE
Support dotnet agent version < 1.5.1

### DIFF
--- a/docker/dotnet/run.sh
+++ b/docker/dotnet/run.sh
@@ -37,7 +37,14 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
   mv /src/NuGet.Config .
   # shellcheck disable=SC2016
   sed -ibck 's#<PropertyGroup>#<PropertyGroup><RestoreSources>$(RestoreSources);/src/local-packages;https://api.nuget.org/v3/index.json</RestoreSources>#' ${CSPROJ}
-  DOTNET_AGENT_VERSION=$(grep 'VersionPrefix' ${BUILD_PROPS} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
+
+  ### Search the version of the agent using VersionPrefix otherwise PackageVersion (to keep backward compatibility)
+  SEARCH="VersionPrefix"
+  if ! grep ${SEARCH} ${BUILD_PROPS} ; then
+    SEARCH="PackageVersion"
+  fi
+
+  DOTNET_AGENT_VERSION=$(grep "${SEARCH}" ${BUILD_PROPS} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
   if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     echo 'INFO: search version in the csproj. (only for agent version < 1.3)'
     DOTNET_AGENT_VERSION=$(grep 'PackageVersion' ${CSPROJ_VERSION} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")

--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -40,8 +40,14 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
   mv /src/NuGet.Config .
   # shellcheck disable=SC2016
   sed -ibck 's#<PropertyGroup>#<PropertyGroup><RestoreSources>$(RestoreSources);/src/local-packages;https://api.nuget.org/v3/index.json</RestoreSources>#' ${CSPROJ}
-  DOTNET_AGENT_VERSION=$(grep 'VersionPrefix' ${BUILD_PROPS} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
 
+  ### Search the version of the agent using VersionPrefix otherwise PackageVersion (to keep backward compatibility)
+  SEARCH="VersionPrefix"
+  if ! grep ${SEARCH} ${BUILD_PROPS} ; then
+    SEARCH="PackageVersion"
+  fi
+
+  DOTNET_AGENT_VERSION=$(grep "${SEARCH}" ${BUILD_PROPS} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
   if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     echo 'INFO: search version in the csproj. (only for agent version < 1.3)'
     DOTNET_AGENT_VERSION=$(grep 'PackageVersion' ${CSPROJ_VERSION} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")


### PR DESCRIPTION
## What does this PR do?

Backward compatibility

## Why is it important?

Just in the hypothetical case there is a requirement to use an old agent version.

